### PR TITLE
Bug_ID 3353 Handled Query to check if period belongs to year selected…

### DIFF
--- a/ModelLibrary/Model/MJournal.cs
+++ b/ModelLibrary/Model/MJournal.cs
@@ -691,7 +691,18 @@ namespace VAdvantage.Model
             {
                 SetDateAcct(GetDateDoc());
             }
-
+            //VIS_427 15/1/2024 Bug_ID 3353 Handled Query to check if period belongs to year selected on header of GL Journal window
+            if(GetGL_JournalBatch_ID() > 0)
+            {
+                string sql = @"SELECT COUNT(C_Period_ID) FROM C_Period WHERE 
+                             C_Year_ID = (SELECT C_Year_ID FROM GL_JournalBatch WHERE GL_JournalBatch_ID=" + GetGL_JournalBatch_ID()+") AND C_Period_ID = " + GetC_Period_ID();
+                int count = Util.GetValueOfInt(DB.ExecuteScalar(sql, null, Get_Trx()));
+                if (count == 0)
+                {
+                    log.SaveError("", Msg.GetMsg(GetCtx(), "VAS_PeriodMisMatch")); 
+                    return false;
+                }
+            }
 
             // set currency of selected accounting schema
             MAcctSchema acctSchema = MAcctSchema.Get(GetCtx(), GetC_AcctSchema_ID());


### PR DESCRIPTION
… on header of GL Journal window

[Coding checklist](https://viennasolutions2.sharepoint.com/:w:/r/sites/FinanceTechnicalTeam/Shared%20Documents/Coding%20Checklist/[CodingChecklist_Official_VAStandard(VAS)_Above_1.2.16.0(2).docx](https://viennasolutions2.sharepoint.com/:w:/r/sites/FinanceTechnicalTeam/Shared%20Documents/Coding%20Checklist/CodingChecklist_Official_VAStandard(VAS)_Above_1.2.16.0(2).docx?d=wec93a7a82f3946a1942e59addab718ac&csf=1&web=1&e=Aryulq)?d=wec93a7a82f3946a1942e59addab718ac&csf=1&web=1&e=Aryulq)

[3353](http://130.61.149.181/ViennaAdvantage/Standard%20ERP-CRM/_dashboards/dashboard/2e84a1e3-c9d3-4ba7-a9ef-7884cd6e356b)