### PR TITLE
On Team Forecast and Master Forecast window:-

### DIFF
--- a/ModelLibrary/Model/MForecast.cs
+++ b/ModelLibrary/Model/MForecast.cs
@@ -78,7 +78,8 @@ namespace VAdvantage.Model
         protected override bool BeforeSave(bool newRecord)
         {
             //Trxdate cant be greater than acctdate
-            if (GetTRXDATE() > GetDateAcct())
+            //VAI082:04-04-2024-Show error message, when account date is less then transaction date.
+            if (GetTRXDATE().Value.Date > GetDateAcct().Value.Date)
             {
                 log.SaveError("TrxDateGreater", "");
                 return false;

--- a/ModelLibrary/Model/MMasterForecast.cs
+++ b/ModelLibrary/Model/MMasterForecast.cs
@@ -78,7 +78,8 @@ namespace VAdvantage.Model
         protected override bool BeforeSave(bool newRecord)
         {
             //Trxdate cant be greater than acctdate
-            if (GetTRXDATE() > GetDateAcct())
+            //VAI082:04-04-2024-Show error message,when account date is less then transaction date.
+            if (GetTRXDATE().Value.Date > GetDateAcct().Value.Date)
             {
                 log.SaveError("TrxDateGreater", "");
                 return false;


### PR DESCRIPTION
Show error message, when account date is less then transaction date.
[Coding  checklist](https://viennasolutions2.sharepoint.com/:w:/r/sites/FinanceTechnicalTeam/Shared%20Documents/Coding%20Checklist/CodingChecklist_Official-VAStandard-ERP-CRM_Above_1.3.2.0.docx?d=wd4c908a21d124419b7efcc479be59cc7&csf=1&web=1&e=0KsqB2)